### PR TITLE
Changed UpcomingEvents logic

### DIFF
--- a/uEvents/Library/Xslt.cs
+++ b/uEvents/Library/Xslt.cs
@@ -38,14 +38,14 @@ namespace uEvents.Library
         public static XPathNodeIterator UpcomingEvents()
         {
             int contentType = DocumentType.GetByAlias("Event").Id;
-            string property = "start";
+            string property = "end";
             
             string sql = string.Format(@"SELECT distinct contentNodeId from cmsPropertyData
             inner join cmsPropertyType ON 
             cmspropertytype.contenttypeid = {0} and
             cmspropertytype.Alias = '{1}' and
             cmspropertytype.id = cmspropertydata.propertytypeid
-            where dataDate > GETDATE()", contentType, property);
+            where dataDate > DATEADD(day,-1,GETDATE())", contentType, property);
 
             ISqlHelper sqlhelper = umbraco.BusinessLogic.Application.SqlHelper;
             IRecordsReader rr = sqlhelper.ExecuteReader(sql);


### PR DESCRIPTION
With logic change an Event in "Upcoming Events" will stay on the list until they have finished (now using end date).  Additionally, since the server datetime seems to be set to somewhere in Europe (+9hrs of Seattle) we show events on the list up to 1 day after they have finished to get around any timezone differences.

Note: please confirm the property alias of the end date is actually "end" - did not see anywhere in the repo where I could see that?
